### PR TITLE
Use log.fatal to print error to stderr and exit 1

### DIFF
--- a/main.go
+++ b/main.go
@@ -113,8 +113,7 @@ func main() {
 	}
 	parsed_data, err := parseData(data, input_format)
 	if err != nil {
-		fmt.Println("ERROR")
-		fmt.Println(err)
+		log.Fatal(err)
 	}
 
 	output_data, _ := outputData(parsed_data, args["--target"].(string))


### PR DESCRIPTION
Closes #2 

```
$ echo '{foo: bar' | go/bin/uq > stdout 2> stderr ; echo "exit code was $?" ; grep '^' stdout stderr
exit code was 1
stderr:2017/03/20 16:57:20 error converting YAML to JSON: yaml: line 1: did not find expected ',' or '}'
```

I don't know much about golang so I'm not sure if this is the right way to do this.